### PR TITLE
PP-5860 Add an smtp server for sentry

### DIFF
--- a/smtp/README.md
+++ b/smtp/README.md
@@ -1,0 +1,14 @@
+## Setting up SMTP for Sentry
+
+Sentry needs access to an SMTP server to send email notificiations. To deploy a
+simple SMTP server using postfix into the PaaS environment follow these instructions:
+
+1. log into the correct org and space e.g. `cf target -s build`
+2. Run `./add_sentry_smtp.sh` which will:
+  - Prompt for various SMTP and PaaS application values
+  - Push a simple smtp server app using the `sentry_smtp_manifest.yml` in this directory
+  - Add a network policy to permit the sentry app to connect to the smtp server
+  app.
+  - Add the SMTP server settings to the sentry app
+  - Restart the Sentry app so that changes take effect.
+  - Setup can be tested visiting `/manage/status/mail/`

--- a/smtp/add_sentry_smtp.sh
+++ b/smtp/add_sentry_smtp.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+read -p "Sentry app name [sentry]: " SENTRY_APP
+SENTRY_APP=${SENTRY_APP:-sentry}
+
+read -p "SMTP user name [sentry]: " SMTP_USER
+SMTP_USER=${SMTP_USER:-sentry}
+
+read -p "SMTP password: " SMTP_PASSWORD
+if [ ${#SMTP_PASSWORD} -le 5 ]
+then
+  echo "Please enter a password at least 5 characters long"
+  exit 1
+fi
+
+read -p "SMTP host [sentry-smtp.apps.internal]: " SMTP_HOST
+SMTP_HOST=${SMTP_HOST:-sentry-smtp.apps.internal}
+
+SMTP_PORT=25
+
+echo "Pushing sentry-smtp"
+cf push -f sentry_smtp_manifest.yml --var smtp_user_and_password=$SMTP_USER:$SMTP_PASSWORD --var docker-username=$DOCKER_USERNAME --var route=$SMTP_HOST
+
+if [ $? -gt 0 ]
+then
+  echo "failed to create smtp server"
+  exit 1
+fi
+
+echo "Adding network policy for sentry to smtp server"
+cf add-network-policy $SENTRY_APP --destination-app sentry-smtp --protocol tcp --port 25
+
+if [ $? -gt 0 ]
+then
+  echo "Failed to add network policies"
+  exit 1
+fi
+
+echo "Provisioning smtp environment variables to sentry"
+cf se $SENTRY_APP SENTRY_SERVER_EMAIL sentry-alert@noreply
+cf se $SENTRY_APP SENTRY_EMAIL_HOST $SMTP_HOST
+cf se $SENTRY_APP SENTRY_EMAIL_PORT $SMTP_PORT
+cf se $SENTRY_APP SENTRY_EMAIL_USER $SMTP_USER
+cf se $SENTRY_APP SENTRY_EMAIL_PASSWORD $SMTP_PASSWORD
+cf se $SENTRY_APP SENTRY_EMAIL_USER_TLS 'false'
+
+if [ $? -gt 0 ]
+then
+  echo "Failed to add smtp environment variables"
+  exit 1
+fi
+
+echo "Restarting sentry"
+cf restart $SENTRY_APP
+
+if [ $? -eq 0 ]
+then
+  echo "Success"
+else
+  echo "Failed to restart sentry"
+fi

--- a/smtp/sentry_smtp_manifest.yml
+++ b/smtp/sentry_smtp_manifest.yml
@@ -1,0 +1,14 @@
+---
+applications:
+  - name: sentry-smtp
+    memory: 1G
+    disk-quota: 1G
+    health-check-type: process
+    routes:
+      - route: ((route))
+    docker:
+      image: catatnight/postfix
+      username: ((docker-username))
+    env:
+      maildomain: sentry.govukpay
+      smtp_user: ((smtp_user_and_password))


### PR DESCRIPTION
To enable Sentry running on PaaS to send email this adds a simple SMTP
server to the space and enables connectivity to Sentry.

For more details please see `README.md`

## NOTES
This has already been done in our Ireland PaaS build space. This PR is to preserve what was done in case it needs to be done again in future.